### PR TITLE
OO 3.* and uv

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-04-28
+
+### Changed
+
+- Bumped OpenOrchestrator to 3.*
+- Switched main.py bootstrap to uv
+
 ## [1.1.7] - 2025-10-21
 
 ### Fixed

--- a/main.py
+++ b/main.py
@@ -9,9 +9,6 @@ import sys
 script_directory = os.path.dirname(os.path.realpath(__file__))
 os.chdir(script_directory)
 
-subprocess.run("python -m venv .venv", check=True)
-subprocess.run(r'.venv\Scripts\pip install .', check=True)
-
-command_args = [r".venv\Scripts\python", "-m", "robot_framework"] + sys.argv[1:]
-
+subprocess.run("pip install --upgrade uv", check=True)
+command_args = ["uv", "run", "python", "-m", "robot_framework"] + sys.argv[1:]
 subprocess.run(command_args, check=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robot_framework"
-version = "1.1.7"
+version = "1.2.0"
 authors = [
   { name="ITK Development", email="itk-rpa@mkb.aarhus.dk" },
 ]
@@ -16,7 +16,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "OpenOrchestrator == 1.*",
+    "OpenOrchestrator == 3.*",
     "Pillow == 9.5.0",
     "itk_dev_shared_components == 2.*",
     "python_serviceplatformen == 3.*",

--- a/robot_framework/process.py
+++ b/robot_framework/process.py
@@ -337,5 +337,5 @@ def check_queue(case_number: str, orchestrator_connection: OrchestratorConnectio
 if __name__ == '__main__':
     conn_string = os.getenv("OpenOrchestratorConnString")
     crypto_key = os.getenv("OpenOrchestratorKey")
-    oc = OrchestratorConnection("Eflyt Test", conn_string, crypto_key, "")
+    oc = OrchestratorConnection("Eflyt Test", conn_string, crypto_key, "", "", "")
     process(oc)

--- a/robot_framework/process.py
+++ b/robot_framework/process.py
@@ -1,6 +1,5 @@
 """This module contains the main process of the robot."""
 
-import os
 from datetime import datetime, timedelta
 from io import BytesIO
 import base64

--- a/robot_framework/process.py
+++ b/robot_framework/process.py
@@ -332,10 +332,3 @@ def check_queue(case_number: str, orchestrator_connection: OrchestratorConnectio
         return False
 
     return True
-
-
-if __name__ == '__main__':
-    conn_string = os.getenv("OpenOrchestratorConnString")
-    crypto_key = os.getenv("OpenOrchestratorKey")
-    oc = OrchestratorConnection("Eflyt Test", conn_string, crypto_key, "", "", "")
-    process(oc)


### PR DESCRIPTION
Bump OpenOrchestrator dependency to 3.* and switch main.py to the uv-based bootstrap.